### PR TITLE
feat: Implement payment integration flow

### DIFF
--- a/backend/app/api/payments.py
+++ b/backend/app/api/payments.py
@@ -46,9 +46,13 @@ async def stripe_webhook(request: Request):
     if event_type == "checkout.session.completed":
         user_id = payload.get("data", {}).get("object", {}).get("client_reference_id")
         if user_id:
-            # In a real app, you would update the user's plan to 'pro' and set the status to 'active'.
-            logging.info(f"Simulating subscription upgrade for user: {user_id}")
-            # For now, we'll just log the event. A full implementation would update the database.
-            pass
+            updated_user = await user_service.update_user(
+                user_id,
+                {"plan": "pro", "status": "active"}
+            )
+            if not updated_user:
+                logging.error(f"Failed to upgrade subscription for user: {user_id}")
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+            logging.info(f"Successfully upgraded subscription for user: {user_id}")
 
     return {"status": "received"}

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -46,3 +46,20 @@ async def get_user_by_id(user_id: str) -> User | None:
     if user_from_db:
         return User(**user_from_db)
     return None
+
+async def update_user(user_id: str, updates: dict) -> Optional[User]:
+    """
+    Updates a user's data in the database.
+    """
+    # Ensure 'updated_at' is always updated on every change.
+    updates["updated_at"] = datetime.utcnow()
+
+    result = await UserCollection.find_one_and_update(
+        {"id": user_id},
+        {"$set": updates},
+        return_document=True
+    )
+
+    if result:
+        return User(**result)
+    return None

--- a/frontend/app/patient/[id].tsx
+++ b/frontend/app/patient/[id].tsx
@@ -47,7 +47,7 @@ interface Patient {
 
 export default function PatientDetailsScreen() {
   const { id } = useLocalSearchParams();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, user } = useAuth();
   const router = useRouter();
   
   const [patient, setPatient] = useState<Patient | null>(null);
@@ -315,6 +315,36 @@ export default function PatientDetailsScreen() {
             <Text style={styles.medicalValue}>{patient.initial_diagnosis || 'Not specified'}</Text>
           </View>
         </View>
+
+        {/* Documents Section (Pro Feature) */}
+        {user?.subscription_plan === 'pro' ? (
+          <View style={styles.notesCard}>
+            <Text style={styles.sectionTitle}>Documents</Text>
+            <TouchableOpacity
+              style={styles.uploadButton}
+              onPress={() => Alert.alert('Upload Document', 'This feature is coming soon!')}
+            >
+              <Ionicons name="cloud-upload" size={20} color="#fff" />
+              <Text style={styles.buttonText}>Upload Document</Text>
+            </TouchableOpacity>
+            <View style={styles.emptyNotes}>
+              <Ionicons name="document-attach-outline" size={48} color="#ccc" />
+              <Text style={styles.emptyNotesText}>No documents yet</Text>
+            </View>
+          </View>
+        ) : (
+          <TouchableOpacity
+            style={styles.upgradeCard}
+            onPress={() => router.push('/upgrade')}
+          >
+            <Ionicons name="rocket-outline" size={32} color="#f39c12" />
+            <View style={styles.upgradeTextContainer}>
+              <Text style={styles.upgradeTitle}>Unlock Document Storage</Text>
+              <Text style={styles.upgradeSubtitle}>Upgrade to Pro to upload and manage patient documents.</Text>
+            </View>
+            <Ionicons name="chevron-forward" size={24} color="#c7c7cc" />
+          </TouchableOpacity>
+        )}
 
         {/* Notes Section */}
         <View style={styles.notesCard}>
@@ -666,10 +696,48 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     gap: 8,
   },
+  uploadButton: {
+    backgroundColor: '#27ae60',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 16,
+    borderRadius: 12,
+    gap: 8,
+    marginBottom: 16,
+  },
   buttonText: {
     color: '#fff',
     fontSize: 16,
     fontWeight: '600',
+  },
+  upgradeCard: {
+    backgroundColor: '#fff',
+    marginHorizontal: 16,
+    marginBottom: 16,
+    padding: 16,
+    borderRadius: 12,
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  upgradeTextContainer: {
+    flex: 1,
+  },
+  upgradeTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#333',
+  },
+  upgradeSubtitle: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 4,
   },
   modalContainer: {
     flex: 1,

--- a/frontend/app/profile.tsx
+++ b/frontend/app/profile.tsx
@@ -36,7 +36,6 @@ export default function ProfileScreen() {
   const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
   const [stats, setStats] = useState<Stats | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [isUpgrading, setIsUpgrading] = useState(false);
   const [userPhoto, setUserPhoto] = useState<string>('');
   const [updatingPhoto, setUpdatingPhoto] = useState(false);
 
@@ -95,31 +94,6 @@ export default function ProfileScreen() {
     }
   };
 
-  const handleUpgrade = async () => {
-    Alert.alert(
-      'Upgrade to Pro',
-      'Upgrade to Pro plan for $9.99/month to access web dashboard and advanced features?',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Upgrade',
-          onPress: async () => {
-            setIsUpgrading(true);
-            try {
-              await axios.post(`${BACKEND_URL}/api/subscription/upgrade`);
-              await refreshUser();
-              await loadProfileData();
-              Alert.alert('Success', 'Successfully upgraded to Pro plan!');
-            } catch (error) {
-              Alert.alert('Error', 'Failed to upgrade subscription');
-            } finally {
-              setIsUpgrading(false);
-            }
-          }
-        }
-      ]
-    );
-  };
 
   const handleLogout = () => {
     Alert.alert(
@@ -434,18 +408,11 @@ export default function ProfileScreen() {
 
               {subscriptionInfo.subscription_plan === 'regular' && (
                 <TouchableOpacity 
-                  style={[styles.upgradeButton, isUpgrading && styles.upgradeButtonDisabled]}
-                  onPress={handleUpgrade}
-                  disabled={isUpgrading}
+                  style={styles.upgradeButton}
+                  onPress={() => router.push('/upgrade')}
                 >
-                  {isUpgrading ? (
-                    <ActivityIndicator color="#fff" size="small" />
-                  ) : (
-                    <>
-                      <Ionicons name="rocket" size={20} color="#fff" />
-                      <Text style={styles.upgradeButtonText}>Upgrade to Pro</Text>
-                    </>
-                  )}
+                  <Ionicons name="rocket" size={20} color="#fff" />
+                  <Text style={styles.upgradeButtonText}>Upgrade to Pro</Text>
                 </TouchableOpacity>
               )}
             </View>
@@ -676,9 +643,6 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderRadius: 8,
     gap: 8,
-  },
-  upgradeButtonDisabled: {
-    backgroundColor: '#95a5a6',
   },
   upgradeButtonText: {
     color: '#fff',

--- a/frontend/app/upgrade.tsx
+++ b/frontend/app/upgrade.tsx
@@ -1,0 +1,220 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  SafeAreaView,
+  ScrollView,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import axios from 'axios';
+import * as WebBrowser from 'expo-web-browser';
+import { useAuth } from '../../contexts/AuthContext';
+
+const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL;
+
+const ProFeatures = [
+  {
+    icon: 'analytics' as const,
+    title: 'Advanced Analytics',
+    description: 'Gain deeper insights with comprehensive patient and practice data.',
+  },
+  {
+    icon: 'cloud-upload' as const,
+    title: 'Document Storage',
+    description: 'Securely upload and manage patient documents like lab reports.',
+  },
+  {
+    icon: 'desktop' as const,
+    title: 'Web Dashboard',
+    description: 'Access a powerful desktop-optimized dashboard for management.',
+  },
+  {
+    icon: 'headset' as const,
+    title: 'Priority Support',
+    description: 'Get faster, dedicated support from our team.',
+  },
+];
+
+export default function UpgradeScreen() {
+  const router = useRouter();
+  const { refreshUser } = useAuth();
+  const [isUpgrading, setIsUpgrading] = useState(false);
+
+  const handleUpgrade = async () => {
+    setIsUpgrading(true);
+    try {
+      const response = await axios.post(`${BACKEND_URL}/api/payments/create-checkout-session`);
+      const { checkout_url } = response.data;
+
+      if (checkout_url) {
+        const result = await WebBrowser.openBrowserAsync(checkout_url);
+        if (result.type === 'cancel' || result.type === 'dismiss') {
+          Alert.alert(
+            'Checking Status...',
+            'We are checking your subscription status. This may take a moment.'
+          );
+        }
+        // After the browser is closed, refresh user data to get new subscription status
+        await refreshUser();
+        router.replace('/profile');
+      } else {
+        throw new Error('Could not get checkout URL.');
+      }
+    } catch (error) {
+      console.error('Upgrade failed:', error);
+      Alert.alert('Upgrade Failed', 'Could not initiate the upgrade process. Please try again later.');
+    } finally {
+      setIsUpgrading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+            <Ionicons name="arrow-back" size={24} color="#333" />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Upgrade to Pro</Text>
+        </View>
+
+        <View style={styles.pitch}>
+          <Ionicons name="rocket" size={48} color="#2ecc71" />
+          <Text style={styles.pitchTitle}>Unlock Your Full Potential</Text>
+          <Text style={styles.pitchSubtitle}>
+            Supercharge your practice with our Pro features, designed for professionals who need more power and flexibility.
+          </Text>
+        </View>
+
+        <View style={styles.featuresList}>
+          {ProFeatures.map((feature, index) => (
+            <View key={index} style={styles.featureItem}>
+              <Ionicons name={feature.icon} size={24} color="#2ecc71" style={styles.featureIcon} />
+              <View style={styles.featureTextContainer}>
+                <Text style={styles.featureTitle}>{feature.title}</Text>
+                <Text style={styles.featureDescription}>{feature.description}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        <TouchableOpacity
+          style={[styles.upgradeButton, isUpgrading && styles.upgradeButtonDisabled]}
+          onPress={handleUpgrade}
+          disabled={isUpgrading}
+        >
+          {isUpgrading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.upgradeButtonText}>Upgrade Now for $9.99/month</Text>
+          )}
+        </TouchableOpacity>
+
+        <Text style={styles.footerText}>
+          You can cancel your subscription at any time.
+        </Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  scrollContent: {
+    paddingBottom: 32,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e9ecef',
+  },
+  backButton: {
+    padding: 8,
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: '#333',
+    marginLeft: 16,
+  },
+  pitch: {
+    alignItems: 'center',
+    padding: 32,
+    backgroundColor: '#f8f9fa',
+  },
+  pitchTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+    marginTop: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  pitchSubtitle: {
+    fontSize: 16,
+    color: '#666',
+    textAlign: 'center',
+    paddingHorizontal: 16,
+  },
+  featuresList: {
+    padding: 24,
+  },
+  featureItem: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginBottom: 24,
+  },
+  featureIcon: {
+    marginRight: 16,
+  },
+  featureTextContainer: {
+    flex: 1,
+  },
+  featureTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#333',
+    marginBottom: 4,
+  },
+  featureDescription: {
+    fontSize: 14,
+    color: '#666',
+  },
+  upgradeButton: {
+    backgroundColor: '#2ecc71',
+    marginHorizontal: 24,
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+  },
+  upgradeButtonDisabled: {
+    backgroundColor: '#95a5a6',
+  },
+  upgradeButtonText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  footerText: {
+    fontSize: 12,
+    color: '#999',
+    textAlign: 'center',
+    marginTop: 16,
+  },
+});


### PR DESCRIPTION
This commit introduces a complete, albeit simulated, payment integration flow, allowing users to upgrade to the Pro plan from within the application.

Key changes:
- **Backend:**
  - Added an `update_user` function to the user service to allow for subscription updates.
  - Implemented a webhook handler (`/api/payments/webhook`) to upgrade a user's plan to 'pro' upon successful payment.
- **Frontend:**
  - Created a dedicated "Upgrade" screen (`frontend/app/upgrade.tsx`) to display the benefits of the Pro plan.
  - Implemented the logic to call the backend to create a checkout session and open the checkout URL in a web browser.
  - Updated all "Upgrade to Pro" prompts to navigate to the new upgrade screen.

This change brings the application closer to the beta release by implementing a critical piece of the subscription model.